### PR TITLE
add architecture to store drive ids csv of harmonized files

### DIFF
--- a/3b_harmonize_chla.R
+++ b/3b_harmonize_chla.R
@@ -59,7 +59,6 @@ p3_chla_targets_list <- list(
     name = p3_cleaned_wqp_data_chl,
     command = p3_wqp_data_aoi_ready_chl$wqp_data_clean_path,
     read = read_feather(path = !!.x),
-    cue = tar_cue("always"),
     packages = "feather"),
   
   
@@ -84,7 +83,6 @@ p3_chla_targets_list <- list(
     name = p3_chla_preagg_grouped,
     command = p3_chla_harmonized$chla_grouped_preagg_path,
     read = read_feather(path = !!.x),
-    cue = tar_cue("always"),
     packages = "feather"),
   
   # Harmonized chlorophyll data after simultaneous record aggregation (i.e.,
@@ -160,7 +158,25 @@ p3_chla_targets_list <- list(
     },
     packages = c("tidyverse", "googledrive"),
     error = "stop"
-  )
+  ),
   
+  # Get file IDs ------------------------------------------------------------
+  
+  # In order to access "stable" versions of the dataset created by the pipeline,
+  # we get their Google Drive file IDs and store those in the repo so that
+  # the harmonization pipeline can retrieve them more easily. The targets below
+  # will include all file IDs in the Drive location, not just stable ones
+  
+  tar_file_read(
+    name = p3_chla_drive_ids,
+    command = get_file_ids(google_email = p0_harmonization_config$google_email,
+                           drive_folder = p0_chl_output_path,
+                           file_path = "3_harmonize/out/chl_drive_ids.csv",
+                           depend = p3_chl_site_info_drive_file
+    ),
+    read = read_csv(file = !!.x),
+    packages = c("tidyverse", "googledrive")
+  )
+
 )
 

--- a/3c_harmonize_doc.R
+++ b/3c_harmonize_doc.R
@@ -156,7 +156,27 @@ p3_doc_targets_list <- list(
       },
     packages = c("tidyverse", "googledrive"),
     error = "stop"
+  ),
+  
+  # Get file IDs ------------------------------------------------------------
+  
+  # In order to access "stable" versions of the dataset created by the pipeline,
+  # we get their Google Drive file IDs and store those in the repo so that
+  # the harmonization pipeline can retrieve them more easily. The targets below
+  # will include all file IDs in the Drive location, not just stable ones
+  
+  # DOC
+  tar_file_read(
+    name = p3_doc_drive_ids,
+    command = get_file_ids(google_email = p0_harmonization_config$google_email,
+                           drive_folder = p0_doc_output_path,
+                           file_path = "3_harmonize/out/doc_drive_ids.csv",
+                           depend = p3_doc_site_info_drive_file
+    ),
+    read = read_csv(file = !!.x),
+    packages = c("tidyverse", "googledrive")
   )
+  
   
 )
 

--- a/3d_harmonize_sdd.R
+++ b/3d_harmonize_sdd.R
@@ -59,7 +59,6 @@ p3_sdd_targets_list <- list(
     name = p3_cleaned_wqp_data_sdd,
     command = p3_wqp_data_aoi_ready_sdd$wqp_data_clean_path,
     read = read_feather(path = !!.x),
-    cue = tar_cue("always"),
     packages = "feather"),
   
   
@@ -84,7 +83,6 @@ p3_sdd_targets_list <- list(
     name = p3_sdd_preagg_grouped,
     command = p3_sdd_harmonized$sdd_grouped_preagg_path,
     read = read_feather(path = !!.x),
-    cue = tar_cue("always"),
     packages = "feather"),
   
   # Harmonized SDD data after simultaneous record aggregation (i.e.,
@@ -160,7 +158,26 @@ p3_sdd_targets_list <- list(
     },
     packages = c("tidyverse", "googledrive"),
     error = "stop"
-  )
+  ),
   
+  # Get file IDs ------------------------------------------------------------
+  
+  # In order to access "stable" versions of the dataset created by the pipeline,
+  # we get their Google Drive file IDs and store those in the repo so that
+  # the harmonization pipeline can retrieve them more easily. The targets below
+  # will include all file IDs in the Drive location, not just stable ones
+  
+  # SDD
+  tar_file_read(
+    name = p3_sdd_drive_ids,
+    command = get_file_ids(google_email = p0_harmonization_config$google_email,
+                           drive_folder = p0_sdd_output_path,
+                           file_path = "3_harmonize/out/sdd_drive_ids.csv",
+                           depend = p3_sdd_site_info_drive_file
+    ),
+    read = read_csv(file = !!.x),
+    packages = c("tidyverse", "googledrive")
+  )
+ 
 )
 

--- a/src/get_file_ids.R
+++ b/src/get_file_ids.R
@@ -1,0 +1,35 @@
+#' @title Function to retrieve Google Drive IDs for a specified folder.
+#' 
+#' @description
+#' A function that retrieves the Google Drive IDs for a folder and exports them
+#' locally as a csv.
+#' 
+#' @param google_email A string containing the gmail address to use for
+#' Google Drive authentication.
+#' 
+#' @param drive_folder A string specifying the Google Drive folder location of
+#' interest.
+#' 
+#' @param file_path The output destination (incl. filename) for the table of
+#' file info.
+#' 
+#' @param depend The (non-string) name of a target that should be run before this,
+#' e.g. to ensure that Drive uploads from earlier in this workflow are considered.
+#'
+#' @return A dribble (Google Drive tibble) containing names and IDs of files
+#' in the specified folder.
+#'
+get_file_ids <- function(google_email, drive_folder, file_path, depend = NULL){
+  
+  # Authorize using the google email provided
+  drive_auth(google_email)
+  
+  # Get info and safe as a csv locally
+  drive_ls(path = drive_folder, recursive = TRUE) %>%
+    select(name, id) %>%
+    write_csv(file = file_path)
+  
+  # Return path for tracking
+  file_path
+  
+}


### PR DESCRIPTION
Just a quick add of architecture to store the drive ids resulting from the harmonization pipeline for siteSR. Closes #93 

Note I removed a number of `cue = tar_cue("always")` in chla and sdd harmonization scripts - I couldn't think of a reason why these would always need to be run and it was causing an error when the pipeline would go to update the `p3_PARAM_site_info_drive_file` since the pipeline was oddly trying to update the Drive file, even though, by logic, this shouldn't be needed. Maybe this is something strange on my end?

I haven't run this with the `admin_update` config, as I was concerned I might sully things up that are in the review queue. 